### PR TITLE
Use watcher in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ php vendor/bin/server run 0.0.0.0:8100 --env=test
 php vendor/bin/server run 0.0.0.0:8100 --dev --debug
 ```
 
+- Watch: the server starts watching its source code. By default false,
+  enabled if the option `--watch` is found. Makes sense on development
+  environment. The server automatically restarts once the changes are detected.
+  By default watches changes in `src` folder in `php` files. See 
+  [docs](https://github.com/seregazhuk/php-watcher) for customization.
+
+```console
+php vendor/bin/server run 0.0.0.0:8100 --dev --watch
+```
+
 ## Serving static files
 
 Kernel Adapters have already defined the static folder related to the kernel.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "react/socket": "^1",
         "react/promise": "^2",
         "react/filesystem": "*",
-        "mmoreram/react-functions": "dev-master"
+        "mmoreram/react-functions": "dev-master",
+        "seregazhuk/php-watcher": "dev-master"
     },
     "require-dev": {
         "drift/http-kernel": "dev-master",

--- a/src/ChangesWatcher.php
+++ b/src/ChangesWatcher.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Drift\Server;
+
+use React\EventLoop\LoopInterface;
+use seregazhuk\PhpWatcher\Config\Builder;
+use seregazhuk\PhpWatcher\Config\WatchList;
+use seregazhuk\PhpWatcher\Filesystem\ChangesListener;
+use seregazhuk\PhpWatcher\Screen\Screen;
+use seregazhuk\PhpWatcher\Screen\SpinnerFactory;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class ChangesWatcher
+{
+    private $loop;
+    private $screen;
+    private $configBuilder;
+
+    public static function isAvailable(): bool
+    {
+        return class_exists('\seregazhuk\PhpWatcher\Config\WatchList');
+    }
+
+    public function __construct(LoopInterface $loop, SymfonyStyle $output)
+    {
+        $this->loop = $loop;
+        $this->screen = new Screen($output, SpinnerFactory::create($output, false));
+        $this->configBuilder = new Builder();
+    }
+
+    public function watch(Application $application): void
+    {
+        $watchList = $this->getWatchList();
+
+        $this->screen->showOptions($watchList);
+        $this->screen->showSpinner($this->loop);
+
+        $filesystemListener = new ChangesListener($this->loop, $watchList);
+        $filesystemListener->on('change', function () use ($application) {
+            $this->restartApplication($application);
+        });
+        $filesystemListener->start();
+    }
+
+    private function getWatchList(): WatchList
+    {
+        $configFilePath = $this->configBuilder->findConfigFile();
+        if ($configFilePath === null) {
+            return new WatchList(['src'], ['php']);
+        }
+
+        return $this->configBuilder->fromConfigFile($configFilePath)->watchList();
+    }
+
+    private function restartApplication(Application $application): void
+    {
+        $this->screen->restarting();
+        $application->stop();
+        $application->run();
+    }
+}


### PR DESCRIPTION
When running in `dev` environment uses [PHP-Watcher](https://github.com/seregazhuk/php-watcher) to reload the server once the source code changes. Listens for changes in `config` and `src` folders and `php, yml` files.

This is how it looks like:

[![asciicast](https://asciinema.org/a/276698.svg)](https://asciinema.org/a/276698)

I'm not sure if I'm stopping the app correctly 🤔 I've removed all listeners, closed the socket and stopped the kernel. Maybe I've missed something here?