### PR TITLE
Fixed missing dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "symfony/http-kernel": "^5.0",
         "symfony/console": "^5.0",
         "symfony/finder": "^4.4 || ^5.0",
+        "symfony/debug": "^4.4",
         "react/http": "^0.8",
         "react/event-loop": "^1.0",
         "react/socket": "^1.0",

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -36,9 +36,12 @@ class ApplicationTest extends TestCase
             "0.0.0.0:$port",
             '--adapter='.FakeAdapter::class,
             '--dev',
+            '--debug',
         ]);
 
         $process->start();
+        $this->assertTrue($process->isRunning());
+
         usleep(300000);
         Utils::curl("http://127.0.0.1:$port/valid/query?code=200");
         usleep(100000);


### PR DESCRIPTION
Hi !

The server failures when is running in debug mode. The call to "Debug::enable()" fail, symfony/debug is missing.

Cheers