### PR TITLE
Fix PHP deprecation warning

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -172,10 +172,9 @@ class Application
                     $uriPath = $request->getUri()->getPath();
                     $uriPath = '/'.ltrim($uriPath, '/');
 
-                    return (0 === strpos(
-                        $uriPath,
-                        $this->serverContext->getStaticFolder()
-                    ))
+                    $staticFolder = $this->serverContext->getStaticFolder();
+
+                    return $staticFolder && (0 === strpos($uriPath, $staticFolder))
                         ? $requestHandler
                             ->handleStaticResource(
                                 $this->loop,


### PR DESCRIPTION
Fix PHP deprecation warning when the option `--no-static-folder` is passed.
```
PHP Deprecated:  strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in vendor/drift/server/src/Application.php on line 177
```