### PR TITLE
Deleted the infinite loop-run block.

### DIFF
--- a/src/Console/ServerCommand.php
+++ b/src/Console/ServerCommand.php
@@ -112,11 +112,10 @@ abstract class ServerCommand extends Command
         );
 
         (new ConsoleServerMessage('EventLoop is running.', '~', true))->print($outputPrinter);
-        while (true) {
-
-            $loop->run();
-            (new ConsoleServerMessage('EventLoop stopped. Running it again', '~', false))->print($outputPrinter);
-        }
+        $loop->run();
+        (new ConsoleServerMessage('EventLoop stopped.', '~', false))->print($outputPrinter);
+        (new ConsoleServerMessage('Closing the server.', '~', false))->print($outputPrinter);
+        (new ConsoleServerMessage('Bye bye!.', '~', false))->print($outputPrinter);
 
         return 0;
     }

--- a/tests/ApplicationStaticFolderTest.php
+++ b/tests/ApplicationStaticFolderTest.php
@@ -94,6 +94,7 @@ class ApplicationStaticFolderTest extends TestCase
                 'Static Folder: disabled'
             ) > 0
         );
+        usleep(500000);
         $content = Utils::curl("http://127.0.0.1:$port/tests/public/app.js");
         $this->assertEmpty($content);
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -39,9 +39,9 @@ class ApplicationTest extends TestCase
         ]);
 
         $process->start();
-        usleep(300000);
+        usleep(500000);
         Utils::curl("http://127.0.0.1:$port/valid/query?code=200");
-        usleep(100000);
+        usleep(500000);
         $this->assertNotFalse(
             strpos(
                 $process->getOutput(),
@@ -76,9 +76,9 @@ class ApplicationTest extends TestCase
         ]);
 
         $process->start();
-        usleep(300000);
+        usleep(500000);
         Utils::curl("http://127.0.0.1:$port?code=200");
-        usleep(100000);
+        usleep(500000);
 
         $this->assertEquals(
             '',
@@ -104,9 +104,9 @@ class ApplicationTest extends TestCase
         ]);
 
         $process->start();
-        usleep(300000);
+        usleep(500000);
         Utils::curl("http://127.0.0.1:$port/another/route?code=200");
-        usleep(300000);
+        usleep(500000);
 
         $this->assertNotFalse(
             strpos(

--- a/tests/CompressionTest.php
+++ b/tests/CompressionTest.php
@@ -49,11 +49,11 @@ class CompressionTest extends TestCase
         ]);
 
         $process->start();
-        usleep(300000);
+        usleep(500000);
         Utils::curl("http://127.0.0.1:$port?code=400", [
             "Accept-Encoding: $encodingType",
         ]);
-        usleep(300000);
+        usleep(500000);
         $this->assertNotFalse(
             strpos(
                 $process->getOutput(),


### PR DESCRIPTION
- The responsibility of re-running the loop when we await a service on
preload event has been passed to the specific component (http-kernel)