### PR TITLE
We should only print messages for errors / >=400

### DIFF
--- a/src/ConsoleRequestMessage.php
+++ b/src/ConsoleRequestMessage.php
@@ -69,7 +69,7 @@ final class ConsoleRequestMessage implements Printable
         $outputPrinter->print("\033[01;{$color}m".$this->code."\033[0m");
         $outputPrinter->print(" $method $this->url ");
         $outputPrinter->print("(\e[00;37m".$this->elapsedTime.' | '.((int) (memory_get_usage() / 1000000))." MB\e[0m)");
-        if ($this->code >= 300) {
+        if ($this->code >= 400) {
             $outputPrinter->print(" - \e[00;37m".$this->messageInMessage($this->message)."\e[0m");
         }
         $outputPrinter->printLine();


### PR DESCRIPTION
At this moment, redirections are printed