### PR TITLE
Terminate event is not dispatched anymore

### DIFF
--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -109,12 +109,6 @@ class RequestHandler
                     resolve($symfonyRequest),
                     $kernel->handleAsync($symfonyRequest),
                 ])
-                ->then(function (array $parts) use ($kernel) {
-                    list($symfonyRequest, $symfonyResponse) = $parts;
-                    $kernel->terminate($symfonyRequest, $symfonyResponse);
-
-                    return $parts;
-                })
                 ->then(function (array $parts) use ($from) {
                     list($symfonyRequest, $symfonyResponse) = $parts;
 


### PR DESCRIPTION
- This event is dispatched for heavy tasks. In ReactPHP you can do the
same by not returning a Promise.