### PR TITLE
Add twig extension to php file watcher for quality of life

### DIFF
--- a/src/Adapter/DriftKernelAdapter.php
+++ b/src/Adapter/DriftKernelAdapter.php
@@ -61,7 +61,7 @@ class DriftKernelAdapter implements KernelAdapter, ObservableKernel
      */
     public static function getObservableExtensions(): array
     {
-        return ['php', 'yml', 'yaml', 'xml', 'css', 'js', 'html'];
+        return ['php', 'yml', 'yaml', 'xml', 'css', 'js', 'html', 'twig'];
     }
 
     /**


### PR DESCRIPTION
It would be great if the php-watcher also looks for changes in .twig files. They are used commonly in Symfony projects. It requires a server restart command now. This addition would improve developers experience.