### PR TITLE
Add symfony kernel adapter

### DIFF
--- a/src/Adapter/SymfonyKernelAdapter.php
+++ b/src/Adapter/SymfonyKernelAdapter.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Drift Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\Server\Adapter;
+
+use Drift\HttpKernel\AsyncKernel;
+use App\Kernel as ApplicationKernel;
+use Drift\Server\Watcher\ObservableKernel;
+
+/**
+ * Class SymfonyKernelAdapter.
+ */
+class SymfonyKernelAdapter implements KernelAdapter, ObservableKernel
+{
+    /**
+     * Build AsyncKernel.
+     */
+    public static function buildKernel(
+        string $environment,
+        bool $debug
+    ): AsyncKernel {
+        return new ApplicationKernel($environment, $debug);
+    }
+
+    /**
+     * Get static folder by kernel.
+     *
+     * @return string|null
+     */
+    public static function getStaticFolder(): ? string
+    {
+        return '/public';
+    }
+
+    /**
+     * Get watcher folders.
+     *
+     * @return string[]
+     */
+    public static function getObservableFolders(): array
+    {
+        return ['src', 'public'];
+    }
+
+    /**
+     * Get watcher folders.
+     *
+     * @return string[]
+     */
+    public static function getObservableExtensions(): array
+    {
+        return ['php', 'yml', 'yaml', 'xml', 'css', 'js', 'html', 'twig'];
+    }
+
+    /**
+     * Get watcher ignoring folders.
+     *
+     * @return string[]
+     */
+    public static function getIgnorableFolders(): array
+    {
+        return [];
+    }
+}

--- a/src/Context/ServerContext.php
+++ b/src/Context/ServerContext.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Drift\Server\Context;
 
+use Drift\Server\Adapter\SymfonyKernelAdapter;
 use Drift\Server\Adapter\DriftKernelAdapter;
 use Drift\Server\Adapter\KernelAdapter;
 use Exception;
@@ -57,6 +58,7 @@ final class ServerContext
         $adapter = $input->getOption('adapter');
         $adapter = [
                 'drift' => DriftKernelAdapter::class,
+                'symfony' => SymfonyKernelAdapter::class,
             ][$adapter] ?? $adapter;
 
         if (!is_a($adapter, KernelAdapter::class, true)) {


### PR DESCRIPTION
The barrier to integrate drift should be relatively low, by integrating
a symfony adapter, developers only need to require the drift/server
package and change there kernel parent class to get started.