### PR TITLE
Automatically choose best supported kernel

### DIFF
--- a/src/Adapter/DriftKernelAdapter.php
+++ b/src/Adapter/DriftKernelAdapter.php
@@ -24,6 +24,11 @@ use Drift\Server\Watcher\ObservableKernel;
  */
 class DriftKernelAdapter implements KernelAdapter, ObservableKernel
 {
+    public static function getKernelClass() : string
+    {
+        return ApplicationKernel::class;
+    }
+
     /**
      * Build AsyncKernel.
      */

--- a/src/Adapter/KernelAdapter.php
+++ b/src/Adapter/KernelAdapter.php
@@ -23,6 +23,11 @@ use Drift\HttpKernel\AsyncKernel;
 interface KernelAdapter
 {
     /**
+     * @return string
+     */
+    public static function getKernelClass() : string;
+
+    /**
      * Build kernel.
      *
      * @param string $environment

--- a/src/Adapter/SymfonyKernelAdapter.php
+++ b/src/Adapter/SymfonyKernelAdapter.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Drift Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\Server\Adapter;
+
+use Drift\HttpKernel\AsyncKernel;
+use App\Kernel as ApplicationKernel;
+use Drift\Server\Watcher\ObservableKernel;
+
+/**
+ * Class SymfonyKernelAdapter.
+ */
+class SymfonyKernelAdapter implements KernelAdapter, ObservableKernel
+{
+    /**
+     * Build AsyncKernel.
+     */
+    public static function buildKernel(
+        string $environment,
+        bool $debug
+    ): AsyncKernel {
+        return new ApplicationKernel($environment, $debug);
+    }
+
+    /**
+     * Get static folder by kernel.
+     *
+     * @return string|null
+     */
+    public static function getStaticFolder(): ? string
+    {
+        return '/public';
+    }
+
+    /**
+     * Get watcher folders.
+     *
+     * @return string[]
+     */
+    public static function getObservableFolders(): array
+    {
+        return ['src', 'public'];
+    }
+
+    /**
+     * Get watcher folders.
+     *
+     * @return string[]
+     */
+    public static function getObservableExtensions(): array
+    {
+        return ['php', 'yml', 'yaml', 'xml', 'css', 'js', 'html', 'twig'];
+    }
+
+    /**
+     * Get watcher ignoring folders.
+     *
+     * @return string[]
+     */
+    public static function getIgnorableFolders(): array
+    {
+        return [];
+    }
+}

--- a/src/Adapter/SymfonyKernelAdapter.php
+++ b/src/Adapter/SymfonyKernelAdapter.php
@@ -24,6 +24,11 @@ use Drift\Server\Watcher\ObservableKernel;
  */
 class SymfonyKernelAdapter implements KernelAdapter, ObservableKernel
 {
+    public static function getKernelClass() : string
+    {
+        return ApplicationKernel::class;
+    }
+
     /**
      * Build AsyncKernel.
      */

--- a/src/Console/ServerCommand.php
+++ b/src/Console/ServerCommand.php
@@ -68,7 +68,7 @@ abstract class ServerCommand extends Command
             ->addOption('no-static-folder', null, InputOption::VALUE_NONE, 'Disable static folder')
             ->addOption('debug', null, InputOption::VALUE_NONE, 'Enable debug')
             ->addOption('no-header', null, InputOption::VALUE_NONE, 'Disabled the header')
-            ->addOption('adapter', null, InputOption::VALUE_OPTIONAL, 'Server Adapter', 'drift');
+            ->addOption('adapter', null, InputOption::VALUE_OPTIONAL, 'Server Adapter');
 
         /*
          * If we have the EventBus loaded, we can add listeners as well

--- a/src/Context/ServerContext.php
+++ b/src/Context/ServerContext.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Drift\Server\Context;
 
+use Drift\Server\Adapter\SymfonyKernelAdapter;
 use Drift\Server\Adapter\DriftKernelAdapter;
 use Drift\Server\Adapter\KernelAdapter;
 use Exception;
@@ -57,6 +58,7 @@ final class ServerContext
         $adapter = $input->getOption('adapter');
         $adapter = [
                 'drift' => DriftKernelAdapter::class,
+                'symfony' => SymfonyKernelAdapter::class,
             ][$adapter] ?? $adapter;
 
         if (!is_a($adapter, KernelAdapter::class, true)) {


### PR DESCRIPTION
Requires #57

Improve DX by automatically choose best supported kernel if no kernel
adapter is specified.

Improve error messages to point developers to required changes.