### PR TITLE
Fake streamed file response

### DIFF
--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -31,7 +31,9 @@ use Drift\Console\OutputPrinter;
 use Drift\Console\TimeFormatter;
 use Drift\HttpKernel\AsyncKernel;
 use Drift\Server\Mime\MimeTypeChecker;
+use React\Http\Io\HttpBodyStream;
 use function React\Promise\all;
+use React\Promise\FulfilledPromise;
 use function React\Promise\resolve;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -42,6 +44,7 @@ use React\Promise\PromiseInterface;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\ThroughStream;
 use RingCentral\Psr7\Response as PSRResponse;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -268,35 +271,49 @@ class RequestHandler
         float $from
     ): PromiseInterface {
         if ($response instanceof Response) {
-            $response = new PSRResponse(
-                $response->getStatusCode(),
-                $response->headers->all(),
-                $response->getContent()
-            );
+            if ($response instanceof BinaryFileResponse) {
+                $streamPromise = $this->filesystem->file($response->getFile()->getPathname())->open('r')->then(function (ReadableStreamInterface $stream) {
+                    return new HttpBodyStream($stream, null);
+                });
+            } else {
+                $streamPromise = new FulfilledPromise($response->getContent());
+            }
+
+            $responsePromise = $streamPromise->then(function ($stream) use($response) {
+                return new PSRResponse(
+                    $response->getStatusCode(),
+                    $response->headers->all(),
+                    $stream
+                );
+            });
+        } else {
+            $responsePromise = new FulfilledPromise($response);
         }
 
-        return $this
-            ->applyResponseEncoding($response, $symfonyRequest->headers->get('Accept-Encoding'))
-            ->then(function (PSRResponse $response) use ($symfonyRequest, $from) {
-                $to = microtime(true);
-                $serverResponse =
-                    new ServerResponseWithMessage(
-                        $response,
-                        $this->outputPrinter,
-                        new ConsoleRequestMessage(
-                            $symfonyRequest->getPathInfo(),
-                            $symfonyRequest->getMethod(),
-                            $response->getStatusCode(),
-                            '',
-                            TimeFormatter::formatTime($to - $from)
-                        )
-                    );
+        return $responsePromise->then(function (PSRResponse $response) use ($symfonyRequest, $from) {
+            return $this
+                ->applyResponseEncoding($response, $symfonyRequest->headers->get('Accept-Encoding'))
+                ->then(function (PSRResponse $response) use ($symfonyRequest, $from) {
+                    $to = microtime(true);
+                    $serverResponse =
+                        new ServerResponseWithMessage(
+                            $response,
+                            $this->outputPrinter,
+                            new ConsoleRequestMessage(
+                                $symfonyRequest->getPathInfo(),
+                                $symfonyRequest->getMethod(),
+                                $response->getStatusCode(),
+                                '',
+                                TimeFormatter::formatTime($to - $from)
+                            )
+                        );
 
-                $symfonyRequest = null;
-                $symfonyResponse = null;
+                    $symfonyRequest = null;
+                    $symfonyResponse = null;
 
-                return $serverResponse;
-            });
+                    return $serverResponse;
+                });
+        });
     }
 
     /**

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -288,16 +288,6 @@ class RequestHandler
                     $response->sendContent();
                     ob_end_flush();
                 });
-            } elseif($response instanceof StreamedResponse) {
-                $streamPromise = new Promise(function($resolve, $reject) use($response) {
-                    $stream = new BufferStream();
-                    $resolve($stream);
-                    ob_start(function($data) use($stream, $resolve, &$isResolved) {
-                        $stream->write($data);
-                    }, 1);
-                    $response->sendContent();
-                    ob_end_flush();
-                });
             } else {
                 $streamPromise = new FulfilledPromise($response->getContent());
             }


### PR DESCRIPTION
Depends on #59

There are two problems with symfony's `StreamedResponse`:

1. It uses a callback to generate the whole output using flush in between. This is by design incompatible with a non blocking approach
2. `Symfony\Component\HttpKernel\EventListener\StreamedResponseListener` is unwrapping the response before it arrives in the kernel. By this, drift is not able to handle the response and output is not been send to the client.

This PR handles the response by passing output to a BufferStream. From what i have seen, this is not really streaming the response anymore, and it is still not removing the blocking IO from symfony's StreamedResponse approach.

Problems that need to be solved are removing the `StreamedResponseListener` as it sends the contents before drift can send it. Any better implementation would require changes to the symfony `StreamedResponse` class.