### PR TITLE
Utilize Symfony Console coloring

### DIFF
--- a/src/Console/ServerCommand.php
+++ b/src/Console/ServerCommand.php
@@ -18,6 +18,8 @@ namespace Drift\Server\Console;
 use Drift\Console\OutputPrinter;
 use Drift\EventBus\Bus\EventBus;
 use Drift\EventLoop\EventLoopUtils;
+use Drift\Server\Console\Style\Muted;
+use Drift\Server\Console\Style\Purple;
 use Drift\Server\ConsoleServerMessage;
 use Drift\Server\Context\ServerContext;
 use Drift\Server\ServerHeaderPrinter;
@@ -96,7 +98,7 @@ abstract class ServerCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $serverContext = ServerContext::buildByInput($input);
-        $outputPrinter = new OutputPrinter($output);
+        $outputPrinter = $this->createOutputPrinter($output);
         $loop = EventLoopFactory::create();
         if ($serverContext->printHeader()) {
             ServerHeaderPrinter::print(
@@ -137,4 +139,21 @@ abstract class ServerCommand extends Command
         ServerContext $serverContext,
         OutputPrinter $outputPrinter
     );
+
+    /**
+     * Create OutputPrinter and add some custom OutputFormatterStyles to the
+     * OutputInterface instance.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return \Drift\Console\OutputPrinter
+     */
+    protected function createOutputPrinter(OutputInterface $output): OutputPrinter
+    {
+        $outputFormatter = $output->getFormatter();
+        $outputFormatter->setStyle('muted', new Muted());
+        $outputFormatter->setStyle('purple', new Purple());
+
+        return new OutputPrinter($output);
+    }
 }

--- a/src/Console/Style/CustomStyle.php
+++ b/src/Console/Style/CustomStyle.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Drift Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\Server\Console\Style;
+
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+
+/**
+ * Class CustomStyle
+ */
+abstract class CustomStyle extends OutputFormatterStyle
+{
+    public function __construct()
+    {
+        // intentionally with no parameters!
+        parent::__construct(null, null, []);
+    }
+}

--- a/src/Console/Style/Muted.php
+++ b/src/Console/Style/Muted.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Drift Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\Server\Console\Style;
+
+/**
+ * Class DriftFormatterStyle
+ */
+final class Muted extends CustomStyle
+{
+    public function apply(string $text)
+    {
+        return sprintf("\e[00;37m%s\e[0m", $text);
+    }
+}

--- a/src/Console/Style/Purple.php
+++ b/src/Console/Style/Purple.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Drift Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\Server\Console\Style;
+
+/**
+ * Class Purple
+ */
+final class Purple extends CustomStyle
+{
+    public function apply(string $text)
+    {
+        return sprintf("\033[01;95m%s\e[0m", $text);
+    }
+}

--- a/src/ConsoleRequestMessage.php
+++ b/src/ConsoleRequestMessage.php
@@ -59,18 +59,18 @@ final class ConsoleRequestMessage implements Printable
     public function print(OutputPrinter $outputPrinter)
     {
         $method = str_pad($this->method, 6, ' ');
-        $color = '32';
+        $color = 'green';
         if ($this->code >= 300 && $this->code < 400) {
-            $color = '33';
+            $color = 'yellow';
         } elseif ($this->code >= 400) {
-            $color = '31';
+            $color = 'red';
         }
 
-        $outputPrinter->print("\033[01;{$color}m".$this->code."\033[0m");
+        $outputPrinter->print("<fg=$color;options=bold>{$this->code}</>");
         $outputPrinter->print(" $method $this->url ");
-        $outputPrinter->print("(\e[00;37m".$this->elapsedTime.' | '.((int) (memory_get_usage() / 1000000))." MB\e[0m)");
+        $outputPrinter->print("(<muted>".$this->elapsedTime.' | '.((int) (memory_get_usage() / 1000000))." MB</muted>)");
         if ($this->code >= 400) {
-            $outputPrinter->print(" - \e[00;37m".$this->messageInMessage($this->message)."\e[0m");
+            $outputPrinter->print(" - <muted>".$this->messageInMessage($this->message)."</muted>");
         }
         $outputPrinter->printLine();
     }

--- a/src/ConsoleServerMessage.php
+++ b/src/ConsoleServerMessage.php
@@ -50,15 +50,15 @@ final class ConsoleServerMessage implements Printable
      */
     public function print(OutputPrinter $outputPrinter)
     {
-        $color = '31';
+        $color = 'red';
         if ($this->ok) {
-            $color = '32';
+            $color = 'green';
         }
 
-        $outputPrinter->print("\033[01;{$color}mSRV\033[0m");
+        $outputPrinter->print("<fg=$color;options=bold>SRV</>");
         $outputPrinter->print(' ');
-        $outputPrinter->print("(\e[00;37m".$this->elapsedTime.' | '.((int) (memory_get_usage() / 1000000))." MB\e[0m)");
-        $outputPrinter->print(" - \e[00;37m".$this->message."\e[0m");
+        $outputPrinter->print("(<muted>".$this->elapsedTime.' | '.((int) (memory_get_usage() / 1000000))." MB</muted>)");
+        $outputPrinter->print(" - <muted>".$this->message."</muted>");
         $outputPrinter->printLine();
     }
 }

--- a/src/ConsoleStaticMessage.php
+++ b/src/ConsoleStaticMessage.php
@@ -47,11 +47,10 @@ final class ConsoleStaticMessage implements Printable
     public function print(OutputPrinter $outputPrinter)
     {
         $method = str_pad('GET', 6, ' ');
-        $color = '95';
 
-        echo "\033[01;{$color}m200\033[0m";
-        echo " $method $this->url ";
-        echo "(\e[00;37m".$this->elapsedTime.' | '.((int) (memory_get_usage() / 1000000))." MB\e[0m)";
-        echo PHP_EOL;
+        $outputPrinter->print('<purple>200</purple>');
+        $outputPrinter->print(" $method $this->url ");
+        $outputPrinter->print("(<muted>".$this->elapsedTime. ' |  ' .((int) (memory_get_usage() / 1000000))." MB</muted>");
+        $outputPrinter->printLine();
     }
 }

--- a/tests/ApplicationStaticFolderTest.php
+++ b/tests/ApplicationStaticFolderTest.php
@@ -49,11 +49,11 @@ class ApplicationStaticFolderTest extends TestCase
             ) > 0
         );
 
-        usleep(100000);
+        usleep(250000);
         $this->assertFileWasReceived("http://127.0.0.1:$port/tests/public/app.js", '$(\'lol\');', 'application/javascript');
         $this->assertFileWasReceived("http://127.0.0.1:$port/tests/public/app.css", '.lol {}', 'text/css');
         $this->assertFileWasReceived("http://127.0.0.1:$port/tests/public/app.txt", 'LOL', 'text/plain');
-        usleep(100000);
+        usleep(250000);
 
         $this->assertNotFalse(
             strpos(

--- a/tests/ApplicationStaticFolderTest.php
+++ b/tests/ApplicationStaticFolderTest.php
@@ -36,6 +36,7 @@ class ApplicationStaticFolderTest extends TestCase
             "0.0.0.0:$port",
             '--adapter='.FakeAdapter::class,
             '--dev',
+            '--ansi'
         ]);
 
         $process->start();
@@ -48,6 +49,7 @@ class ApplicationStaticFolderTest extends TestCase
             ) > 0
         );
 
+        usleep(100000);
         $this->assertFileWasReceived("http://127.0.0.1:$port/tests/public/app.js", '$(\'lol\');', 'application/javascript');
         $this->assertFileWasReceived("http://127.0.0.1:$port/tests/public/app.css", '.lol {}', 'text/css');
         $this->assertFileWasReceived("http://127.0.0.1:$port/tests/public/app.txt", 'LOL', 'text/plain');

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -36,6 +36,7 @@ class ApplicationTest extends TestCase
             "0.0.0.0:$port",
             '--adapter='.FakeAdapter::class,
             '--dev',
+            '--ansi'
         ]);
 
         $process->start();
@@ -45,7 +46,7 @@ class ApplicationTest extends TestCase
         $this->assertNotFalse(
             strpos(
                 $process->getOutput(),
-                '[01;32m200[0m GET'
+                '[32;1m200[39;22m GET'
             )
         );
 
@@ -101,6 +102,7 @@ class ApplicationTest extends TestCase
             "0.0.0.0:$port",
             '--adapter='.FakeAdapter::class,
             '--dev',
+            '--ansi'
         ]);
 
         $process->start();
@@ -111,7 +113,38 @@ class ApplicationTest extends TestCase
         $this->assertNotFalse(
             strpos(
                 $process->getOutput(),
-                '[01;31m404[0m GET'
+                '[31;1m404[39;22m GET'
+            )
+        );
+
+        $process->stop();
+    }
+
+    /**
+     * Test non blocking server.
+     */
+    public function testNonAnsi()
+    {
+        $port = rand(2000, 9999);
+        $process = new Process([
+            'php',
+            dirname(__FILE__).'/../bin/server',
+            'run',
+            "0.0.0.0:$port",
+            '--adapter='.FakeAdapter::class,
+            '--dev',
+            '--no-ansi'
+        ]);
+
+        $process->start();
+        usleep(500000);
+        Utils::curl("http://127.0.0.1:$port/query?code=200");
+        usleep(500000);
+
+        $this->assertNotFalse(
+            strpos(
+                $process->getOutput(),
+                '200 GET'
             )
         );
 

--- a/tests/WatcherTest.php
+++ b/tests/WatcherTest.php
@@ -35,6 +35,7 @@ class WatcherTest extends TestCase
             'watch',
             "0.0.0.0:$port",
             '--adapter='.FakeAdapter::class,
+            '--ansi'
         ]);
 
         $process->start();
@@ -44,7 +45,7 @@ class WatcherTest extends TestCase
         $this->assertNotFalse(
             strpos(
                 $output,
-                '[01;32m200[0m GET'
+                '[32;1m200[39;22m GET'
             )
         );
         $process->stop();


### PR DESCRIPTION
Utilize [Symfony Console coloring](https://symfony.com/doc/current/console/coloring.html), so you can use the `--no-ansi` option, to disable color, e.g. when you want to parse the output for log aggregation.