### PR TITLE
Improved + Fixed static content delivery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "react/event-loop": "^1.0",
         "react/socket": "^1.0",
         "react/promise": "^2.7",
-        "react/filesystem": "^0.1",
+        "react/filesystem": "dev-master as 0.1.3",
         "clue/zlib-react": "^0.2.2",
         "drift/console-bridge": "0.1.*",
         "drift/event-loop-utils": "0.1.*"

--- a/src/Application.php
+++ b/src/Application.php
@@ -320,8 +320,8 @@ class Application
 
         return $filesystem
             ->file($rootPath.$resourcePath)
-            ->open('r')
-            ->then(function (ReadableStreamInterface $stream) use ($rootPath, $resourcePath, $from, $request) {
+            ->getContents()
+            ->then(function (string $content) use ($rootPath, $resourcePath, $from, $request) {
                 $mimeType = $this
                     ->mimeTypeChecker
                     ->getMimeType($resourcePath);
@@ -329,7 +329,7 @@ class Application
                 $response = new ReactResponse(
                     200,
                     ['Content-Type' => $mimeType],
-                    $stream
+                    $content
                 );
 
                 return $this


### PR DESCRIPTION
- In order to avoid loading static content in memory, what makes sense,
static content was being served with stream. The problem was that the
efficiency was extremely poor. Current filesystem implementation uses
ChildProcess to load the whole data in memory, what makes it extremely
more efficient (from ms to seconds for a 700kB files).
- This error was avoided by loading the file in memory, what is not a
big deal (you can work with an external server for static content, or
just add a CDN to serve these files after the first time
- Updated Filesystem version to dev-master. Last version was from more
than 2 years ago. The library is properly tested and is stable, so that
makes sense.