### PR TITLE
Emulate PHP auth headers for Symfony security bundle

### DIFF
--- a/src/Adapter/DriftKernel/DriftKernelAdapter.php
+++ b/src/Adapter/DriftKernel/DriftKernelAdapter.php
@@ -275,6 +275,16 @@ class DriftKernelAdapter implements KernelAdapter
                     + $symfonyRequest->server->all()
                 );
 
+                if ($symfonyRequest->headers->has('authorization') &&
+                    0 === stripos($symfonyRequest->headers->get('authorization'), 'basic ')) {
+                    $exploded = explode(':', base64_decode(substr($symfonyRequest->headers->get('authorization'), 6)), 2);
+                    if (2 == \count($exploded)) {
+                        list($basicAuthUsername, $basicAuthPassword) = $exploded;
+                        $symfonyRequest->headers->set('PHP_AUTH_USER', $basicAuthUsername);
+                        $symfonyRequest->headers->set('PHP_AUTH_PW', $basicAuthPassword);
+                    }
+                }
+
                 $symfonyRequest->attributes->set('body', $request->getBody());
 
                 if (isset($headers['Host'])) {

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -245,6 +245,8 @@ class ApplicationTest extends TestCase
 
     /**
      * Test server values.
+     *
+     * @group lol
      */
     public function testServerValues()
     {
@@ -254,13 +256,41 @@ class ApplicationTest extends TestCase
             dirname(__FILE__).'/../bin/server',
             'run',
             "0.0.0.0:$port",
-            '--adapter='.FakeLaminasKernel::class,
+            '--adapter='.FakeAdapter::class,
         ]);
 
         $process->start();
         usleep(500000);
         list($_, $_, $code) = Utils::curl("http://127.0.0.1:$port/check-server-vars?port=$port");
         $this->assertEquals(200, $code);
+        usleep(500000);
+
+        $process->stop();
+    }
+
+    /**
+     * Test server values.
+     */
+    public function testBasicAuthHeaders()
+    {
+        $port = rand(2000, 9999);
+        $process = new Process([
+            'php',
+            dirname(__FILE__).'/../bin/server',
+            'run',
+            "0.0.0.0:$port",
+            '--adapter='.FakeAdapter::class,
+        ]);
+
+        $process->start();
+        usleep(500000);
+        list($content) = Utils::curl("http://127.0.0.1:$port/auth", [
+            'authorization: basic '.base64_encode('my_key:my_value'),
+        ]);
+
+        $headers = json_decode($content, true);
+        $this->assertEquals('my_key', $headers['user']);
+        $this->assertEquals('my_value', $headers['password']);
         usleep(500000);
 
         $process->stop();

--- a/tests/FakeKernel.php
+++ b/tests/FakeKernel.php
@@ -180,6 +180,13 @@ class FakeKernel extends AsyncKernel
             ], $code);
         }
 
+        if ('/auth' === $pathInfo) {
+            return new JsonResponse([
+                'user' => $request->headers->get('PHP_AUTH_USER'),
+                'password' => $request->headers->get('PHP_AUTH_PW'),
+            ], $code);
+        }
+
         if ('/streamed-body' === $pathInfo) {
             $stream = $request->attributes->get('body');
 
@@ -202,10 +209,11 @@ class FakeKernel extends AsyncKernel
 
         if ('/check-server-vars' === $pathInfo) {
             $server = $request->server;
+
             $code = (
                 '/check-server-vars' === $server->get('REQUEST_URI') &&
                 '127.0.0.1' === $server->get('REMOTE_ADDR') &&
-                $server->get('REMOTE_PORT') === $request->query->get('port')
+                \intval($server->get('SERVER_PORT')) === \intval($request->query->get('port'))
             ) ? 200 : 500;
 
             return new JsonResponse([], $code);


### PR DESCRIPTION
Rebased and copied the PR from - https://github.com/driftphp/server/pull/66

- Thanks to @Deltachaos for his work
- Covered the feature with tests
- Added a small testing fix from previous merged PR