### PR TITLE
Added support for the Symfony kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ chapter)
 - [Workers](#workers)
 - [Watcher](#watcher)
 - [Static server](#static-server)
+- [Symfony bridge](#symfony-bridge)
+- [DriftPHP resources](#driftphp-resources)
 
 ## Installation
 
@@ -189,6 +191,21 @@ php vendor/bin/server watch 0.0.0.0:8000 --static-folder=/public/:/internal/publ
 In this example, a file named `app.js` located under `/internal/public/path/` 
 folder will be accessible at `http://localhost:8000/public/app.js`. By default,
 this feature is disabled.
+
+## Symfony bridge
+
+In order to help you from migrating an application from Symfony to DriftPHP, 
+assuming that this means that your whole domain should turn on top of Promises, 
+including your infrastructure layer, this server is distributed with a small
+Symfony adapter. Use it as a tool, and never use it at production (using a
+ReactPHP based server in a blocking application is something not recommendable
+at all in terms of performance and service availability). That adapter will help
+your migrating from one platform to the other, as will allow this server to work
+with your Symfony kernel.
+
+```bash
+php vendor/bin/server watch 0.0.0.0:8000 --adapter=symfony
+```
 
 ## DriftPHP resources
 

--- a/src/Adapter/SymfonyKernel/SymfonyKernelAdapter.php
+++ b/src/Adapter/SymfonyKernel/SymfonyKernelAdapter.php
@@ -13,20 +13,21 @@
 
 declare(strict_types=1);
 
-namespace Drift\Server\Adapter\DriftKernel;
+namespace Drift\Server\Adapter\SymfonyKernel;
 
+use App\Kernel as ApplicationKernel;
 use Drift\HttpKernel\AsyncKernel;
-use Drift\Kernel as ApplicationKernel;
 use Drift\Server\Adapter\SymfonyKernelBasedAdapter;
 use Exception;
 use React\Promise\PromiseInterface;
+use function React\Promise\resolve;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
- * Class DriftKernelAdapter.
+ * Class SymfonyKernelAdapter.
  */
-class DriftKernelAdapter extends SymfonyKernelBasedAdapter
+class SymfonyKernelAdapter extends SymfonyKernelBasedAdapter
 {
     /**
      * @param $kernel
@@ -35,9 +36,7 @@ class DriftKernelAdapter extends SymfonyKernelBasedAdapter
      */
     protected function checkKernel($kernel)
     {
-        if (!$kernel instanceof AsyncKernel) {
-            throw new SyncKernelException('The kernel should implement AsyncKernel interface, as you are using the DriftPHP kernel adapter');
-        }
+        // No checks here
     }
 
     /**
@@ -63,7 +62,7 @@ class DriftKernelAdapter extends SymfonyKernelBasedAdapter
         Kernel $kernel,
         Request $request
     ): PromiseInterface {
-        return $kernel->handleAsync($request);
+        return resolve($kernel->handle($request));
     }
 
     /**
@@ -71,7 +70,7 @@ class DriftKernelAdapter extends SymfonyKernelBasedAdapter
      */
     public function shutDown(): PromiseInterface
     {
-        return $this->kernel->shutdown();
+        // Nothing to do here
     }
 
     /**
@@ -81,6 +80,6 @@ class DriftKernelAdapter extends SymfonyKernelBasedAdapter
      */
     public static function getObservableFolders(): array
     {
-        return ['Drift', 'src', 'public', 'views'];
+        return ['App', 'src', 'public', 'views'];
     }
 }

--- a/src/Adapter/SymfonyKernelBasedAdapter.php
+++ b/src/Adapter/SymfonyKernelBasedAdapter.php
@@ -1,0 +1,357 @@
+<?php
+
+/*
+ * This file is part of the Drift Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\Server\Adapter;
+
+use Drift\Console\OutputPrinter;
+use Drift\EventBus\Subscriber\EventBusSubscriber;
+use Drift\HttpKernel\AsyncKernel;
+use Drift\Server\Context\ServerContext;
+use Drift\Server\Exception\KernelException;
+use Drift\Server\Exception\RouteNotFoundException;
+use Drift\Server\Mime\MimeTypeChecker;
+use Exception;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface as PsrUploadedFile;
+use React\EventLoop\LoopInterface;
+use React\Filesystem\FilesystemInterface;
+use React\Http\Message\Response as ReactResponse;
+use function React\Promise\all;
+use React\Promise\PromiseInterface;
+use function React\Promise\resolve;
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Exception\RouteNotFoundException as SymfonyRouteNotFoundException;
+use Throwable;
+
+/**
+ * Class SymfonyKernelBasedAdapter.
+ */
+abstract class SymfonyKernelBasedAdapter implements KernelAdapter
+{
+    protected Kernel $kernel;
+    private FilesystemInterface $filesystem;
+    private ServerContext $serverContext;
+    private MimeTypeChecker $mimeTypeChecker;
+    private string $rootPath;
+
+    /**
+     * @param string $environment
+     * @param bool   $debug
+     *
+     * @return AsyncKernel
+     */
+    abstract protected static function createKernelByEnvironmentAndDebug(
+        string $environment,
+        bool $debug
+    ): AsyncKernel;
+
+    /**
+     * @param $kernel
+     *
+     * @throws Exception
+     */
+    abstract protected function checkKernel($kernel);
+
+    /**
+     * @param Kernel  $kernel
+     * @param Request $request
+     *
+     * @return PromiseInterface
+     */
+    abstract protected function kernelHandle(
+        Kernel $kernel,
+        Request $request
+    ): PromiseInterface;
+
+    /**
+     * @param LoopInterface       $loop
+     * @param string              $rootPath
+     * @param ServerContext       $serverContext
+     * @param FilesystemInterface $filesystem
+     * @param OutputPrinter       $outputPrinter
+     * @param MimeTypeChecker     $mimeTypeChecker
+     *
+     * @return PromiseInterface<self>
+     *
+     * @throws KernelException
+     */
+    public static function create(
+        LoopInterface $loop,
+        string $rootPath,
+        ServerContext $serverContext,
+        FilesystemInterface $filesystem,
+        OutputPrinter $outputPrinter,
+        MimeTypeChecker $mimeTypeChecker
+    ): PromiseInterface {
+        $adapter = new static();
+        $kernel = static::createKernelByEnvironmentAndDebug($serverContext->getEnvironment(), $serverContext->isDebug());
+
+        $kernel->boot();
+        $kernel
+            ->getContainer()
+            ->set('reactphp.event_loop', $loop);
+
+        $adapter->kernel = $kernel;
+        $adapter->serverContext = $serverContext;
+        $adapter->filesystem = $filesystem;
+        $adapter->mimeTypeChecker = $mimeTypeChecker;
+        $adapter->rootPath = $rootPath;
+
+        return $kernel
+            ->preload()
+            ->then(function () use ($adapter, $outputPrinter) {
+                $container = $adapter->kernel->getContainer();
+                $serverContext = $adapter->serverContext;
+
+                if (
+                    $serverContext->hasExchanges() &&
+                    $container->has(EventBusSubscriber::class)
+                ) {
+                    $eventBusSubscriber = $container->get(EventBusSubscriber::class);
+                    $eventBusSubscriber->subscribeToExchanges(
+                        $serverContext->getExchanges(),
+                        $outputPrinter
+                    );
+                }
+            })
+            ->then(function () use ($adapter) {
+                return $adapter;
+            });
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     *
+     * @return PromiseInterface<ResponseInterface>
+     */
+    public function handle(ServerRequestInterface $request): PromiseInterface
+    {
+        $uriPath = $request->getUri()->getPath();
+        $method = $request->getMethod();
+
+        return
+            $this->toSymfonyRequest(
+                $request,
+                $method,
+                $uriPath
+            )
+                ->then(function (Request $symfonyRequest) use ($request) {
+                    return all([
+                        resolve($symfonyRequest),
+                        $this->kernelHandle($this->kernel, $symfonyRequest),
+                    ])
+                        ->otherwise(function (SymfonyRouteNotFoundException $symfonyRouteNotFoundException) {
+                            throw new RouteNotFoundException($symfonyRouteNotFoundException->getMessage());
+                        })
+                        ->then(function (array $parts) use ($request) {
+                            list($symfonyRequest, $symfonyResponse) = $parts;
+
+                            /*
+                             * We don't have to wait to this clean
+                             */
+                            $this->cleanTemporaryUploadedFiles($symfonyRequest);
+                            $symfonyRequest = null;
+
+                            $response = $symfonyResponse;
+                            if ($response instanceof Response) {
+                                $response = new ReactResponse(
+                                    $response->getStatusCode(),
+                                    $response->headers->all(),
+                                    $response->getContent()
+                                );
+                            }
+
+                            return $response;
+                        });
+                });
+    }
+
+    /**
+     * Http request to symfony request.
+     *
+     * @param ServerRequestInterface $request
+     * @param string                 $method
+     * @param string                 $uriPath
+     *
+     * @return PromiseInterface<Request>
+     */
+    private function toSymfonyRequest(
+        ServerRequestInterface $request,
+        string $method,
+        string $uriPath
+    ): PromiseInterface {
+        $allowFileUploads = !$this
+            ->serverContext
+            ->areFileUploadsDisabled();
+
+        $uploadedFiles = $allowFileUploads
+            ? array_map(function (PsrUploadedFile $file) {
+                return $this->toSymfonyUploadedFile($file);
+            }, $request->getUploadedFiles())
+            : [];
+
+        return all($uploadedFiles)
+            ->then(function (array $uploadedFiles) use ($request, $method, $uriPath) {
+                $uploadedFiles = array_filter($uploadedFiles);
+                $headers = $request->getHeaders();
+                $isNotTransferEncoding = !array_key_exists('Transfer-Encoding', $headers);
+
+                $bodyParsed = [];
+                $bodyContent = '';
+                if ($isNotTransferEncoding) {
+                    $bodyParsed = $request->getParsedBody() ?? [];
+                    $bodyContent = $request->getBody()->getContents();
+                }
+
+                $symfonyRequest = new Request(
+                    $request->getQueryParams(),
+                    $bodyParsed,
+                    $request->getAttributes(),
+                    $this->serverContext->areCookiesDisabled()
+                        ? []
+                        : $request->getCookieParams(),
+                    $uploadedFiles,
+                    $_SERVER,
+                    $bodyContent
+                );
+
+                $symfonyRequest->setMethod($method);
+                $symfonyRequest->headers->replace($headers);
+
+                $symfonyRequest->server->replace(
+                    $request->getServerParams()
+                    + ['REQUEST_URI' => $uriPath]
+                    + $symfonyRequest->server->all()
+                );
+
+                if ($symfonyRequest->headers->has('authorization') &&
+                    0 === stripos($symfonyRequest->headers->get('authorization'), 'basic ')) {
+                    $exploded = explode(':', base64_decode(substr($symfonyRequest->headers->get('authorization'), 6)), 2);
+                    if (2 == \count($exploded)) {
+                        list($basicAuthUsername, $basicAuthPassword) = $exploded;
+                        $symfonyRequest->headers->set('PHP_AUTH_USER', $basicAuthUsername);
+                        $symfonyRequest->headers->set('PHP_AUTH_PW', $basicAuthPassword);
+                    }
+                }
+
+                $symfonyRequest->attributes->set('body', $request->getBody());
+
+                if (isset($headers['Host'])) {
+                    $symfonyRequest->server->set('SERVER_NAME', explode(':', $headers['Host'][0]));
+                }
+
+                return $symfonyRequest;
+            });
+    }
+
+    /**
+     * PSR Uploaded file to Symfony file.
+     *
+     * @param PsrUploadedFile $file
+     *
+     * @return PromiseInterface<SymfonyUploadedFile>
+     */
+    private function toSymfonyUploadedFile(PsrUploadedFile $file): PromiseInterface
+    {
+        if (UPLOAD_ERR_NO_FILE == $file->getError()) {
+            return resolve(new SymfonyUploadedFile(
+                '',
+                $file->getClientFilename(),
+                $file->getClientMediaType(),
+                $file->getError(),
+                true
+            ));
+        }
+
+        $filename = $file->getClientFilename();
+        $extension = $this->mimeTypeChecker->getExtension($filename);
+        $tmpFilename = sys_get_temp_dir().'/'.md5(uniqid((string) rand(), true)).'.'.$extension;
+
+        try {
+            $content = $file
+                ->getStream()
+                ->getContents();
+        } catch (Throwable $throwable) {
+            return resolve(false);
+        }
+
+        $promise = (UPLOAD_ERR_OK == $file->getError())
+            ? $this
+                ->filesystem
+                ->file($tmpFilename)
+                ->putContents($content)
+            : resolve();
+
+        return $promise
+            ->then(function () use ($file, $tmpFilename, $filename) {
+                return new SymfonyUploadedFile(
+                    $tmpFilename,
+                    $filename,
+                    $file->getClientMediaType(),
+                    $file->getError(),
+                    true
+                );
+            });
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return PromiseInterface[]
+     */
+    private function cleanTemporaryUploadedFiles(Request $request): array
+    {
+        return array_map(function (SymfonyUploadedFile $file) {
+            return $this
+                ->filesystem
+                ->file($file->getPath().'/'.$file->getFilename())
+                ->remove();
+        }, $request->files->all());
+    }
+
+    /**
+     * Get watcher folders.
+     *
+     * @return string[]
+     */
+    public static function getObservableExtensions(): array
+    {
+        return ['php', 'yml', 'yaml', 'xml', 'css', 'js', 'html', 'twig'];
+    }
+
+    /**
+     * Get watcher ignoring folders.
+     *
+     * @return string[]
+     */
+    public static function getIgnorableFolders(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get static folder by kernel.
+     *
+     * @return string|null
+     */
+    public static function getStaticFolder(): ? string
+    {
+        return '/public';
+    }
+}

--- a/src/Console/ServerCommand.php
+++ b/src/Console/ServerCommand.php
@@ -71,7 +71,7 @@ abstract class ServerCommand extends Command
             ->addOption('no-file-uploads', null, InputOption::VALUE_NONE, 'Disable file uploads')
             ->addOption('concurrent-requests', null, InputOption::VALUE_OPTIONAL, 'Limit of concurrent requests', 100)
             ->addOption('request-body-buffer', null, InputOption::VALUE_OPTIONAL, 'Limit of the buffer used for the Request body. In KiB.', 1024)
-            ->addOption('adapter', null, InputOption::VALUE_OPTIONAL, 'Server Adapter', 'drift')
+            ->addOption('adapter', null, InputOption::VALUE_OPTIONAL, 'Server Adapter. Can be a namespace or a shortcut. Available shortcuts [drift, symfony]', 'drift')
             ->addOption('allowed-loop-stops', null, InputOption::VALUE_OPTIONAL, 'Number of allowed loop stops', 0)
             ->addOption('workers', null, InputOption::VALUE_OPTIONAL,
                 'Number of workers. Use -1 to get as many workers as physical thread available for your system. Maximum of 128 workers. Option disabled for watch command.', 1

--- a/src/Context/ServerContext.php
+++ b/src/Context/ServerContext.php
@@ -17,6 +17,7 @@ namespace Drift\Server\Context;
 
 use Drift\Server\Adapter\DriftKernel\DriftKernelAdapter;
 use Drift\Server\Adapter\KernelAdapter;
+use Drift\Server\Adapter\SymfonyKernel\SymfonyKernelAdapter;
 use Exception;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -64,6 +65,7 @@ final class ServerContext
         $adapter = $input->getOption('adapter');
         $adapter = [
                 'drift' => DriftKernelAdapter::class,
+                'symfony' => SymfonyKernelAdapter::class,
             ][$adapter] ?? $adapter;
 
         if (!is_a($adapter, KernelAdapter::class, true)) {

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -295,4 +295,37 @@ class ApplicationTest extends TestCase
 
         $process->stop();
     }
+
+    /**
+     * Test Symfony adapter.
+     */
+    public function testSymfonyAdapter()
+    {
+        $port = rand(2000, 9999);
+        $process = new Process([
+            'php',
+            dirname(__FILE__).'/../bin/server',
+            'run',
+            "0.0.0.0:$port",
+            '--adapter='.FakeSymfonyAdapter::class,
+            '--dev',
+            '--ansi',
+        ]);
+
+        $process->start();
+        usleep(500000);
+        Utils::curl("http://127.0.0.1:$port/query?code=200");
+        usleep(500000);
+        $this->assertContains(
+            '[32;1m200[39;22m GET',
+            $process->getOutput()
+        );
+
+        $this->assertContains(
+            '/query',
+            $process->getOutput()
+        );
+
+        $process->stop();
+    }
 }

--- a/tests/FakeSymfonyAdapter.php
+++ b/tests/FakeSymfonyAdapter.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Drift Server
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Drift\Server\Tests;
+
+use Drift\HttpKernel\AsyncKernel;
+use Drift\Server\Adapter\SymfonyKernel\SymfonyKernelAdapter;
+
+/**
+ * Class FakeSymfonyAdapter.
+ */
+class FakeSymfonyAdapter extends SymfonyKernelAdapter
+{
+    /**
+     * @param string $environment
+     * @param bool   $debug
+     *
+     * @return AsyncKernel
+     */
+    protected static function createKernelByEnvironmentAndDebug(
+        string $environment,
+        bool $debug
+    ): AsyncKernel {
+        return new FakeKernel($environment, $debug);
+    }
+}


### PR DESCRIPTION
- This feature was introduced in https://github.com/driftphp/server/pull/57/files
- Thanks to @Deltachaos for the idea and the implementation
- Added documentation
- Added an abstraction, so both the drift and the symfony kernels can
work the same way in terms of transformation between ReactPHP http
component and the Symfony kernel component